### PR TITLE
Added roles to User, replaced silly way of checking for admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,3 @@
 .byebug_history
 
 /config/local_env.yml
-/config/admins.yml

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,6 @@ class User < ApplicationRecord
   has_many :events, through: :registrations
 
   def is_admin?
-    $ADMINS.include? self.email
+    self.role == "admin"
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,9 +16,6 @@ module UwindsorCssEventsSite
       YAML.load(File.open(env_file)).each do |key, value|
         ENV[key.to_s] = value
       end if File.exists?(env_file)
-
-      admin_file = File.join(Rails.root, 'config', 'admins.yml')
-      $ADMINS = YAML.load(File.open(admin_file))["ADMINS"]
     end
 
     # Settings in config/environments/* take precedence over those specified here.

--- a/db/migrate/20190212065547_add_role_to_users.rb
+++ b/db/migrate/20190212065547_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :role, :string, default: "guest"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190212055136) do
+ActiveRecord::Schema.define(version: 20190212065547) do
 
   create_table "events", force: :cascade do |t|
     t.string "title"
@@ -42,6 +42,7 @@ ActiveRecord::Schema.define(version: 20190212055136) do
     t.datetime "updated_at", null: false
     t.string "email"
     t.string "name"
+    t.string "role", default: "guest"
   end
 
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Instead of storing admins in a `admins.yml` file and loading on startup, simply add a role attribute to the `User` model (default is guest) which can be checked.

### How are you accomplishing it?

- Added 'role' to `User` model (default == "guest")
- Removed `admins.yml` and loading of it
- Check `user.role` instead of `ADMINS` global variable

### Is there anything reviewers should know?

Nothing I can think of.

- [x] Is it safe to rollback this change if anything goes wrong?
