### PR TITLE
Added capacity option in  new/edit event form

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -35,7 +35,7 @@ class EventsController < ApplicationController
   end
 
   def create
-    @event = Event.new(params.require(:event).permit(:title, :description))
+    @event = Event.new(event_params)
     if current_user&.is_admin?
       if @event.save
         redirect_to @event
@@ -58,6 +58,6 @@ class EventsController < ApplicationController
   private
 
   def event_params
-    params.require(:event).permit(:title, :description)
+    params.require(:event).permit(:title, :description, :capacity)
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,6 +4,7 @@ class Event < ApplicationRecord
   has_many :guests, through: :registrations
 
   validates :title, :description, presence: true, length: { minimum: 3 }
+  validates :capacity, presence: true
 
   def current_capacity
     return self.users.size + self.guests.size

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -33,6 +33,14 @@
               <%= form.text_area :description, :class => 'materialize-textarea' %>
             </div>
           </div>
+          <div class="row">
+            <div class="input-field col s12">
+              <!--CAPACITY-->
+              <i class="material-icons prefix">capacity</i>
+              <%= form.label :capacity %><br>
+              <%= form.text_area :capacity, :class => 'materialize-textarea' %>
+            </div>
+          </div>
           <div class="row center">
             <%= form.submit 'Update event', :class => 'waves-effect waves-light btn' %>
           </div>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -33,6 +33,14 @@
             <%= form.text_area :description, :class => 'materialize-textarea' %>
           </div>
         </div>
+        <div class="row">
+          <div class="input-field col s12">
+            <!--CAPACITY-->
+            <i class="material-icons prefix">capacity</i>
+            <%= form.label :capacity %><br>
+            <%= form.text_field :capacity %>
+          </div>
+        </div>
         <div class="row center">
           <%= form.submit 'Add', :class => 'waves-effect waves-light btn' %>
         </div>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1490434/52766382-d8041400-2fdb-11e9-8e02-d470d9ed3aa5.png)


### What are you trying to accomplish?
Add a field on the edit/new form to set the event capacity.

### How are you accomplishing it?
- Added field to form
- Added `capacity` to the permitted arguments for new/edit events

### Is there anything reviewers should know?
Nope

- [x] Is it safe to rollback this change if anything goes wrong?
