### PR TITLE
Fixed edit form creating new events instead of editing

### DIFF
--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with scope: :event, url: events_path, local: true do |form| %>
+<%= form_with model: @event, local: true do |form| %>
   <% if @event.errors.any? %>
     <div id="error_explanation" class="container error-newhtml">
       <p><b>


### PR DESCRIPTION
### What are you trying to accomplish?

Noticed that when I pushed https://github.com/EricPickup/uwindsor-css-events-site/pull/15 I didn't alter the form to distinguish between editing and creating. Editing an event was making it create a new event with those changes instead.

### How are you accomplishing it?

Rails magic

### Is there anything reviewers should know?
Nope


- [x] Is it safe to rollback this change if anything goes wrong?
