### PR TITLE
Visibility fixes for guests

### DIFF
--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -19,10 +19,12 @@
                 </div>
                 <div class="card-action">
                   <%= link_to 'Show', event_path(event) %>
-                  <%= link_to 'Edit', edit_event_path(event) %>
-                  <%= link_to 'Delete', event_path(event),
-                  method: :delete,
-                  data: { confirm: 'Are you sure?' } %>
+                  <% if current_user&.is_admin? %>
+                    <%= link_to 'Edit', edit_event_path(event) %>
+                    <%= link_to 'Delete', event_path(event),
+                    method: :delete,
+                    data: { confirm: 'Are you sure?' } %>
+                  <% end %>
                 </div>
               </div>
             </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -14,6 +14,8 @@
           <%= link_to 'Register', new_registration_path(event_id: @event.id, user_id: current_user.id), :class => 'waves-effect waves-light btn'  %>
         <% end %>
         </div>
+      <% else %>
+         <a class="btn disabled">Sign in to Register</a>
       <% end %>
       <div class="row">
       <% if current_user&.is_admin? %><%= link_to 'Edit ', edit_event_path(@event) %>|<% end %>


### PR DESCRIPTION
### What are you trying to accomplish?
**1) Visibility fixes**
![image](https://user-images.githubusercontent.com/1490434/52836623-31ce1200-30a0-11e9-95e7-f20ff4762edd.png)

**2) Disabled register button**
![image](https://user-images.githubusercontent.com/1490434/52836626-35619900-30a0-11e9-9c5c-a6fb9fc0645b.png)

Guests and non-admins shouldn't be shown the "Edit" and "Delete" event buttons.

Also added a disabled button on event `show` so users understand they need to sign in to register.

### How are you accomplishing it?

Straight forward.

### Is there anything reviewers should know?

Nope

- [x] Is it safe to rollback this change if anything goes wrong?
