### PR TITLE
Disable registration event when event is full

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -10,8 +10,10 @@
       <div class="center" style="padding: 30px">
         <% if @registration %>
           <%= link_to 'Unregister', registration_path(event_id: @event.id, registration_id: @registration), method: :delete, :class => 'waves-effect waves-light btn'  %>
-        <% else %>
+        <% elsif @event.current_capacity < @event.capacity %>
           <%= link_to 'Register', new_registration_path(event_id: @event.id, user_id: current_user.id), :class => 'waves-effect waves-light btn'  %>
+        <% else %>
+          <a class="btn disabled">Event Full</a>
         <% end %>
         </div>
       <% else %>


### PR DESCRIPTION
### What are you trying to accomplish?
![image](https://user-images.githubusercontent.com/1490434/52836962-a786ad80-30a1-11e9-8d66-c97634d766ad.png)


To avoid conflicts and confusion, disable the registration button when event is full.

### How are you accomplishing it?

Simple if statement.

### Is there anything reviewers should know?

Nope.

- [x] Is it safe to rollback this change if anything goes wrong?
