### PR TITLE
Added guest list for events

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -34,6 +34,13 @@ class EventsController < ApplicationController
     end
   end
 
+  def guests
+    @event = Event.find(params[:id])
+    unless current_user&.is_admin?
+      display_404
+    end
+  end
+
   def create
     @event = Event.new(event_params)
     if current_user&.is_admin?

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -9,4 +9,8 @@ class Event < ApplicationRecord
   def current_capacity
     return self.users.size + self.guests.size
   end
+
+  def all_guests
+    self.users + self.guests
+  end
 end

--- a/app/views/events/guests.html.erb
+++ b/app/views/events/guests.html.erb
@@ -1,0 +1,7 @@
+<ol>
+  <% @event.all_guests.each do |guest| %>
+    <li><%= guest.name %> - <%= guest.email %></li>
+  <% end %>
+</ol>
+
+<%= link_to 'Back', event_path(@event) %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -20,7 +20,9 @@
          <a class="btn disabled">Sign in to Register</a>
       <% end %>
       <div class="row">
-      <% if current_user&.is_admin? %><%= link_to 'Edit ', edit_event_path(@event) %>|<% end %>
+      <% if current_user&.is_admin? %>
+        <%= link_to 'Edit', edit_event_path(@event) %> | <%= link_to 'Guest List', guests_event_path(@event) %> | 
+      <% end %>
       <%= link_to 'Back', events_path %>
       </div>
     </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,9 @@ Rails.application.routes.draw do
    # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html	  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root :to => "events#index"
 
-  resources :events
+  resources :events do
+    get :guests, on: :member
+  end
+
   resources :registration
 end


### PR DESCRIPTION
### What are you trying to accomplish?
**1) Guest list page**
![image](https://user-images.githubusercontent.com/1490434/52838131-70ff6180-30a6-11e9-9680-2c028ab52284.png)

**2) Guest list button on `show` for admins**
![image](https://user-images.githubusercontent.com/1490434/52838135-752b7f00-30a6-11e9-9db3-4379a709a85c.png)

Create a guest list page to show all registered guests for an event. Only admins can see this information.

### How are you accomplishing it?
- Add `all_guests` method to `Event` that adds all users and their guests
- Added `/events/:id/guests` route with `guests.html.erb` view
- View lists all guests emails and names
- Show `404` if non-admin tries to access

### Is there anything reviewers should know?
Nope


- [x] Is it safe to rollback this change if anything goes wrong?
