### PR TITLE
Added location URL option in form and link to URL on event page

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -65,6 +65,6 @@ class EventsController < ApplicationController
   private
 
   def event_params
-    params.require(:event).permit(:title, :description, :capacity, :date, :location)
+    params.require(:event).permit(:title, :description, :capacity, :date, :location, :location_url)
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,7 +3,7 @@ class Event < ApplicationRecord
   has_many :users, through: :registrations
   has_many :guests, through: :registrations
 
-  validates :title, :description, presence: true, length: { minimum: 3 }
+  validates :title, :description, :location, :date, presence: true, length: { minimum: 3 }
   validates :capacity, presence: true
 
   def current_capacity

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -51,6 +51,14 @@
             <%= form.text_field :location %>
           </div>
         </div>
+        <!--LOCATION URL-->
+        <div class="row">
+          <div class="input-field col s12">
+            <i class="material-icons prefix">insert_link</i>
+            <%= form.label "Location URL" %><br>
+            <%= form.text_field :location_url %>
+          </div>
+        </div>
         <!--DATE-->
         <div class="row">
           <div class="input-field col s12">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -4,8 +4,14 @@
     <p style="text-align:left;"><b>Description: </b><%= @event.description %><p>
     <p style="text-align:left;"><b>Capacity: </b><%= "#{@event.current_capacity}/#{@event.capacity}" %><p>
     <p style="text-align:left;"><b>Date: </b><%= @event.date.strftime('%B %d, %Y at %l:%M %p') %><p>
-    <!-- Buttons for calendar and maps<p style="text-align:left;"><b>Location: </b><%= @event.location %>Insert link here<a href="#">  (View on Maps)</a><p>
-    <a class="btn-floating red tooltipped" data-position="top" data-tooltip="Add to Calendar"><i class="material-icons">calendar_today</i></a>-->
+    <p style="text-align:left;">
+      <b>Location: </b>
+      <% if @event.location_url&.present? %>
+        <%= link_to @event.location, @event.location_url, target: :_blank %>
+      <% else %>
+        <%= @event.location %>
+      <% end %>
+    <p>
     <p>
       <% if current_user %>
       <div class="center" style="padding: 30px">

--- a/db/migrate/20190220033103_add_location_url_to_events.rb
+++ b/db/migrate/20190220033103_add_location_url_to_events.rb
@@ -1,0 +1,5 @@
+class AddLocationUrlToEvents < ActiveRecord::Migration[5.1]
+  def change
+    add_column :events, :location_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190214071222) do
+ActiveRecord::Schema.define(version: 20190220033103) do
 
   create_table "events", force: :cascade do |t|
     t.string "title"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 20190214071222) do
     t.datetime "updated_at", null: false
     t.integer "capacity"
     t.datetime "date"
+    t.string "location_url"
   end
 
   create_table "guests", force: :cascade do |t|
@@ -35,6 +36,7 @@ ActiveRecord::Schema.define(version: 20190214071222) do
     t.integer "event_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "capacity"
     t.index ["event_id"], name: "index_registrations_on_event_id"
     t.index ["user_id"], name: "index_registrations_on_user_id"
   end


### PR DESCRIPTION
![location url gif](https://user-images.githubusercontent.com/1490434/53065807-1c7f2c00-3482-11e9-8f17-e59e4f7575f8.gif)

![image](https://user-images.githubusercontent.com/1490434/53065817-230da380-3482-11e9-89dd-b9f501ef6760.png)

### What are you trying to accomplish?

Simple way to link users to the address or URL. Add the URL option in the form and this will be added as a link on the location field when showing an event.

### How are you accomplishing it?

- Add `location_url` column to `Event`
- Add location URL option in event form
- Check if location URL exists - If so, add link to location print

### Is there anything reviewers should know?

Keep in mind that I don't mention Maps because we could potentially post events that are hosted over Hangouts (online) and the link could be for Hangouts instead of Maps.


- [x] Is it safe to rollback this change if anything goes wrong?
